### PR TITLE
update enclosed tarball to 4.0.6

### DIFF
--- a/src/build.pl
+++ b/src/build.pl
@@ -80,6 +80,42 @@ chdir(${NAME});
 my $hwloc_opts = '';
 if ($ENV{HWLOC_DIR} ne '' and $ENV{HWLOC_DIR} ne 'NO_BUILD') {
     $hwloc_opts = "--with-hwloc='$ENV{HWLOC_DIR}'";
+    # MPI must link to all the extra HWLOC libs but does not do so by default
+    my $hwloc_libs = "";
+    for my $lib (split(/\s+/,$ENV{HWLOC_LIBS})) {
+      if($lib =~ m/^-/) {
+        $hwloc_libs .= " $lib";
+      } else {
+        $hwloc_libs .= " -l$lib";
+      }
+    }
+    if ($hwloc_libs ne '') {
+      $ENV{LIBS} .= $hwloc_libs;
+    }
+    # OpenMPI assumes a regular usr/lib and usr/include set of paths so we need
+    # to communicate to it any differences
+    my $hwloc_lib_dirs = "";
+    for my $dir (split(/\s+/,$ENV{HWLOC_LIB_DIRS})) {
+      if($dir =~ m/^-/) {
+        $hwloc_lib_dirs .= " $dir";
+      } else {
+        $hwloc_lib_dirs .= " -L$dir";
+      }
+    }
+    if ($hwloc_lib_dirs ne '') {
+      $ENV{LDFLAGS} .= $hwloc_lib_dirs;
+    }
+    my $hwloc_inc_dirs = "";
+    for my $dir (split(/\s+/,$ENV{HWLOC_INC_DIRS})) {
+      if($dir =~ m/^-/) {
+        $hwloc_inc_dirs .= " $dir";
+      } else {
+        $hwloc_inc_dirs .= " -I$dir";
+      }
+    }
+    if ($hwloc_inc_dirs ne '') {
+      $ENV{CFLAGS} .= $hwloc_inc_dirs;
+    }
 }
 # Cannot have a memory manager with a static library on some systems
 # (e.g. Linux); see

--- a/src/build.pl
+++ b/src/build.pl
@@ -23,7 +23,7 @@ if ($verbose) {
 
 # Set locations
 my $THORN = "MPI";
-my $NAME = "openmpi-4.0.2";
+my $NAME = "openmpi-4.0.6";
 my $INSTALL_DIR = undef;
 my $BUILD_DIR = undef;
 my $SRCDIR = $0;

--- a/src/detect.pl
+++ b/src/detect.pl
@@ -167,7 +167,7 @@ if ($mpi_build and !$mpi_info_set) {
     }
     my $mpi_linux_libs = '';
     if ($^O eq 'linux') {
-        $mpi_linux_libs = "rt util";
+        $mpi_linux_libs = "pthread rt util";
     }
     $ENV{MPI_LIBS} = "$mpi_fortranlibs mpi_cxx mpi open-rte open-pal $mpi_linux_libs";
 } else {

--- a/src/make.code.deps
+++ b/src/make.code.deps
@@ -1,6 +1,6 @@
 # Main make.code.deps file for thorn MPI
 
-export MPI_INSTALL_DIR HWLOC_DIR
+export MPI_INSTALL_DIR HWLOC_DIR HWLOC_LIBS HWLOC_LIB_DIRS HWLOC_INC_DIRS
 
 $(CCTK_TARGET) $(OBJS) $(SRCS:%=%.d): $(SCRATCH_BUILD)/done/$(THORN)
 


### PR DESCRIPTION
This pull request is actually two changes.

* first to update the enclosed tarball to version 4.0.6 which is the latest version available in the still supported 4.0.X series of releases. I am not updating to 4.1.X since that version introduces a new library orte-npir or so that is not correctly reported as required by `mpicc -showme:link` so leads to link time failures for static linking.
* second, add required options to LIBS and CFLAGS, LDFLAGS to ensure all libraries required for hwloc (eg udev) are correctly linked in to avoid configure time failures in when OpenMPI's configure tries to check if hwloc is functinal
* thridly add pthread to the list of "Linux" libraries since OpenMPI's IO subsystem can use it and linking fails whithout. I am not using an option dependency on ExternalLibraries/PTHREAD because the depenency is in fact not option and happens even when ExternalLibraries/PTHREAD is not linked in.